### PR TITLE
Added scrollbar to status box

### DIFF
--- a/src/components/StatusMessage.js
+++ b/src/components/StatusMessage.js
@@ -205,18 +205,20 @@ const Instruction = ({ handleClose, statusMessage, taskgroup }) => {
     </div>
   )
   return (
-    <div>
-      <Paper className='status-box'>
-        <Clear
-          className='clear'
-          onClick={() => handleClose()}
-        />
-        {statusMessage.text}
-        {statusMessage.status && statusMessage.status.nonMandatory
-          ? statusbox()
-          : null}
-      </Paper>
-    </div>
+    <div className='status-message-container'>
+      <div className='inner-status-message-container'>
+        <Paper className='status-box'>
+          <Clear
+            className='clear'
+            onClick={() => handleClose()}
+          />
+          {statusMessage.text}
+          {statusMessage.status && statusMessage.status.nonMandatory
+            ? statusbox()
+            : null}
+        </Paper>
+      </div>
+    </div >
   )
 }
 
@@ -243,8 +245,8 @@ class StatusMessage extends React.Component {
         style={{ marginTop: 30 }}
       />
     ) : (
-      <InfoButton handleOpen={this.props.handleOpen} />
-    )
+        <InfoButton handleOpen={this.props.handleOpen} />
+      )
     return element
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -461,11 +461,12 @@ span.label {
 
 /* #### STATUS BOX #### */
 .status-box {
-  width: 90%;
+  width: 100%;
   margin: 5px;
   margin-right: 0;
   padding-left: 20px;
   font-size: 0.9rem;
+  position: absolute;
 }
 .status-box .done {
   width: 15px;
@@ -496,6 +497,17 @@ span.label {
   margin: 10px;
   margin-left: 20px;
 }
+.status-message-container {
+  position: relative;
+  height: 100%;
+}
+.inner-status-message-container {
+  position: relative;
+  overflow-y: auto;
+  height: 100%;
+  width: 90%;
+}
+
 
 /* #### BUFFER ZONE #### */
 #bufferzone {


### PR DESCRIPTION
If the screen is too small, add a scrollbar to status message.

If you make the screen smaller, the scrollbar doesn't appear for some reason. But if you keep the same display height the scrollbar will appear when the entire message doesn't fit on the screen.
Making the screen larger however makes the scrollbar disappear. Some css-weirdness going on.