### PR TITLE
Allows edit-event to be missing a closing function in props

### DIFF
--- a/src/components/EditEvent.js
+++ b/src/components/EditEvent.js
@@ -73,7 +73,9 @@ class EditEvent extends React.Component {
       this.props.editEvent(moddedEvent)
       this.props.bufferZoneInitialization(0)
       // await eventService.edit(data);
-      this.props.source()
+      if (this.props.source) {
+        this.props.source()
+      }
       this.setState({ open: false })
       this.props.notify('Tapahtuman muokkaus onnistui!', 'success')
     } catch (exception) {


### PR DESCRIPTION
Retains legacy functionality, though the original handleClose-functions passed as source in EventCard seem to be gone.