### PR TITLE
Some fixes to smaller eventcards

### DIFF
--- a/src/components/Activity.js
+++ b/src/components/Activity.js
@@ -91,13 +91,13 @@ class Activity extends Component {
             className={chipClass}
             key={activity.id}
             onClick={this.handleClick}
-            style={this.props.minimal ? {height: '25px'} : {} }
+            style={this.props.minimal ? {height: '25px'} : {}}
             avatar={
               <Avatar
                 alt='Mandatory Icon'
                 src={pofActivity.mandatoryIconUrl}
                 className={avatarClass}
-                style={this.props.minimal ? {height: '28px'} : {}}
+                style={this.props.minimal ? {height: '24px'} : {}}
               />
             }
             label={pofActivity.title}

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -225,9 +225,13 @@ class EventCard extends React.Component {
       />
     )
 
+    // This is used to make unexpended elements smaller
+    // It seems that using style is easiest way to override material ui styles
+    const cardStyle=this.state.expanded ? {'padding-top':'3px','padding-right':'12px'} : {padding: '3px 12px 3px 3px'}
+
 
     const touchDeviceNotExpanded = (
-      <CardContent style={this.state.expanded ? {} : {padding: '3px' }}>
+      <CardContent style={cardStyle}>
         <div className="mobile-event-card-media">
           <Activities
             activities={this.props.event.activities}
@@ -267,7 +271,7 @@ class EventCard extends React.Component {
       </CardContent>
     )
     const notExpanded = (
-      <CardContent style={this.state.expanded ? {} : {padding: '3px' } }>
+      <CardContent style={cardStyle}>
         <div className="activity-header">
           <Activities
             activities={this.props.event.activities}
@@ -305,7 +309,7 @@ class EventCard extends React.Component {
         <Card>
           <ActivityDragAndDropTarget bufferzone={false} parentId={this.props.event.id}>
             <CardHeader
-              style={this.state.expanded ? {} : {padding: '3px' }}
+              style={cardStyle}
               title={
                 <div>
                   {title}
@@ -335,7 +339,7 @@ class EventCard extends React.Component {
             { !isTouchDevice() && !this.state.expanded ? notExpanded  : null }
             { this.state.expanded ? expanded : null }
 
-            <CardActions style={this.state.expanded ? {} : {padding: '3px' }}>
+            <CardActions style={cardStyle}>
               <EditEvent
                 buttonClass="buttonRight"
                 data={event}

--- a/src/index.css
+++ b/src/index.css
@@ -99,8 +99,8 @@ p.eventTimes > span {
 
 .mandatory-chip-avatar-minimal > img,
 .non-mandatory-chip-avatar-minimal > img  {
-  height: 26px !important;
-  width: 26px !important;
+  height: 22px !important;
+  width: 22px !important;
   color: #1a237e;
   margin: 4px;
 
@@ -533,13 +533,12 @@ span.label {
 }
 
 .tooltip {
-  position: relative;
   display: inline-block;
+  position: relative;
 }
 
 .tooltip .tooltiptext {
-  visibility: hidden;
-  min-width: 200px;
+  min-width: 230px;
   font-size: 14px;
   background-color: black;
   color: #fff;
@@ -548,6 +547,13 @@ span.label {
   padding: 5px;
   z-index: 1;
 }
+
+.tooltiptext {
+  visibility: hidden;
+  position: absolute;
+  display: inline-block;
+}
+
 
 .tooltip:hover .tooltiptext {
   visibility: visible;


### PR DESCRIPTION
- expanding button doesn't jump around
- tooltiptext position to absolute (so it doesn't cause the time to jump to the next line)
- smaller mandatory-icon on mini activities