### PR TITLE
Bugfix: Don't show activities in Kuksa events in calendar

### DIFF
--- a/src/reducers/eventReducer.js
+++ b/src/reducers/eventReducer.js
@@ -81,6 +81,7 @@ export const deleteSyncedEvent = event => async dispatch => {
   // Add the event back to the list of Kuksa events (to show on the "Kuksa" page)
   event.id = "kuksa" + event.kuksaEventId
   event.kuksaEvent = true
+  event.activities = []
   dispatch({
     type: 'ADD_EVENT',
     event: event


### PR DESCRIPTION
Bug description:

1. Lisää kuksaEvent omaan suunnitelmaan
2. Poista synced event
3. Kalenterissa näkyy edelleen aktiviteetit